### PR TITLE
Fix required ruby version

### DIFF
--- a/fintoc.gemspec
+++ b/fintoc.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.summary       = 'The official Ruby client for the Fintoc API.'
   spec.description   = 'The official Ruby client for the Fintoc API.'
   spec.homepage      = 'https://github.com/fintoc-com/fintoc-ruby'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.3.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.6.0')
 
   # spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
 


### PR DESCRIPTION
This repository uses ruby 2.6 functionalities to work as expected. Specifically Enumerator::Chain on Utils file

Docs:
https://rubyreferences.github.io/rubychanges/2.6.html#enumerator-chaining
