### PR TITLE
Release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 1.2.0 - 2026-04-08
+
+### 🚀 New Features
+
+- **Account Statements**: Added `account_statements` resource under v2 accounts for retrieving account statements
+- **Account Number Deletion**: Added `delete` method for account numbers in the v2 API
+- **Movements**: Added `movements` resource under v2 accounts
+
 ## 1.1.0 - 2025-09-15
 
 ### 🚀 New Features

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fintoc (1.1.0)
+    fintoc (1.2.0)
       http
       money-rails
       tabulate

--- a/lib/fintoc/version.rb
+++ b/lib/fintoc/version.rb
@@ -1,3 +1,3 @@
 module Fintoc
-  VERSION = '1.1.0'
+  VERSION = '1.2.0'
 end


### PR DESCRIPTION
## Contexto

Release de la versión 1.2.0 del gem. Corresponde al tag [v1.2.0](https://github.com/fintoc-com/fintoc-ruby/releases/tag/v1.2.0).

## ¿Qué hay de nuevo?

Bump de versión y actualización del changelog para el release.

- [x] Versión actualizada a `1.2.0` en `lib/fintoc/version.rb`
- [x] CHANGELOG actualizado con los cambios de esta versión

## Tests

- [x] No hay cambios funcionales, solo versión y changelog

## Safety Checks

- [x] Versión y CHANGELOG actualizados

## Consideraciones

Una vez mergeado, se debe hacer `gem build` y `gem push` para publicar en RubyGems.

## Rollback

Sí, es seguro. Revertir el commit y volver a la versión 1.1.0.