### PR TITLE
[DX-586] add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Tipo de bump'
+        type: choice
+        required: true
+        default: minor
+        options: [patch, minor, major]
+      release-notes:
+        description: 'Release notes (markdown, opcional)'
+        type: string
+        required: false
+
+jobs:
+  release:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2.2'
+          bundler-cache: true
+
+      - run: bundle exec rubocop
+      - run: bundle exec rspec
+
+      - uses: fintoc-com/release-action/prepare@main
+        id: prep
+        with:
+          bump: ${{ inputs.bump }}
+          version-format: ruby
+          tag-prefix: v
+          app-id: ${{ vars.FIN_RELEASES_APP_ID }}
+          app-private-key: ${{ secrets.FIN_RELEASES_PRIVATE_KEY }}
+
+      - name: Build and push gem
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+        run: |
+          gem build *.gemspec
+          gem push *.gem
+
+      - uses: fintoc-com/release-action/finalize@main
+        with:
+          tag: ${{ steps.prep.outputs.tag }}
+          release-notes: ${{ inputs.release-notes }}
+          app-id: ${{ vars.FIN_RELEASES_APP_ID }}
+          app-private-key: ${{ secrets.FIN_RELEASES_PRIVATE_KEY }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,25 @@
+# Releasing
+
+Manual desde Actions. Toma ~3–4 min.
+
+## Cómo
+
+1. https://github.com/fintoc-com/fintoc-ruby/actions → **Release** → **Run workflow**.
+2. `bump`: `patch` / `minor` / `major`. `release-notes`: markdown opcional.
+3. **Run workflow**. Solo corre desde `main`.
+
+## Qué hace
+
+`bundle install` + `rubocop` + `rspec` →
+[`release/prepare`](https://github.com/fintoc-com/release-action/tree/main/prepare) bumpea `lib/fintoc/version.rb` (y refresca `Gemfile.lock`) →
+`gem build *.gemspec` + `gem push *.gem` (con `RUBYGEMS_API_KEY`) →
+[`release/finalize`](https://github.com/fintoc-com/release-action/tree/main/finalize) pushea commit + tag, crea GitHub Release.
+
+Todo autoreado por `fin-releases[bot]`.
+
+## Si falla
+
+| Falla en | Estado | Recovery |
+|---|---|---|
+| Antes o durante `gem push` | Nada en el remote | Re-run |
+| `release/finalize` (post-publish) | Gem en RubyGems, sin tag/release | PR con el commit del bump + `gh release create vX.Y.Z` |


### PR DESCRIPTION
## Contexto

fintoc-ruby es el único SDK que no tenía workflow de release — los gems se subían a mano. Este PR agrega el flow consistente con los otros repos (npm/python): manual dispatch con bump elegido en la UI, identidad `fin-releases[bot]`, GitHub Release.

## ¿Qué hay de nuevo?

- **`.github/workflows/release.yml`**: workflow_dispatch (`bump` + `release-notes` inputs), gated a `main`. Corre rubocop + rspec, después `release/prepare` → `gem build` + `gem push` → `release/finalize`.
- **`RELEASING.md`**: doc corta del flow.
- **`bump-ruby.sh`** en [release-action](https://github.com/fintoc-com/release-action) (commit `169fad2`): bumpea `lib/fintoc/version.rb` y refresca `Gemfile.lock`.

### Flujo

```
rubocop + rspec → release/prepare → gem build + gem push → release/finalize
```

Detalle de prepare/finalize: igual que en los otros SDKs. Si `gem push` falla, lo de prepare vive solo en el runner — el remote no se toca. Si falla finalize después del push, el gem ya está en RubyGems pero falta el tag/release; recovery es PR con el commit + `gh release create`.

## Tests

- rubocop + rspec corren en cada release (mismas suites que `ci.yml`).
- No hay tests del workflow propio. Primer test real va a ser apretar Run workflow con `bump: patch` (v1.2.0 → v1.2.1).

## Safety Checks

- [x] Versión bumpeada por el bot (no hace falta `make bump!` manual previo)
- [x] App `fin-releases` ya en bypass del branch protection de `main`

## Consideraciones

**Hay que crear el secret `RUBYGEMS_API_KEY` antes de gatillar el primer release.** El gemspec tiene `rubygems_mfa_required = true`, así que el API key debe venir de una cuenta de RubyGems con MFA habilitada y con scope `push_rubygem`.



Otras notas:
- Tags actuales (`v1.0.0`, `v1.1.0`, `v1.2.0`) ya usan prefix `v`. El workflow pasa `tag-prefix: v` para mantener convención.


## Rollback

Seguro.