### PR TITLE
chore: bump version to 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 1.3.0 - 2026-07-07
+
+### 🚀 New Features
+
+- **Entity Onboardings**: Added `onboardings` resource under v2 entities to manage the onboarding process
+  - `list`, `get`, `create` and `submit` methods for onboardings
+  - `upload_document` to upload a document to a specific slot
+  - `upload_shareholder_document` to upload a shareholder's document
+  - `upload_legal_representative_document` to upload a legal representative's document
+- **Entity Creation**: Added `create` method for entities in the v2 API
+- **Webhook Endpoints**: Added `webhook_endpoints` manager to create, retrieve, list, update, delete and test webhook endpoints
+- **Multipart Uploads**: The HTTP client now supports `multipart/form-data` requests, used for document uploads
+
 ## 1.2.0 - 2026-04-08
 
 ### 🚀 New Features

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fintoc (1.2.0)
+    fintoc (1.3.0)
       http
       money-rails
       tabulate

--- a/lib/fintoc/version.rb
+++ b/lib/fintoc/version.rb
@@ -1,3 +1,3 @@
 module Fintoc
-  VERSION = '1.2.0'
+  VERSION = '1.3.0'
 end


### PR DESCRIPTION
## Contexto

El release v1.3.0 quedó a medias: el tag y el release en GitHub existen desde junio, pero nunca se hizo el bump de versión ni se publicó la gema. En RubyGems seguimos en 1.2.0, así que nadie que instale `fintoc` tiene los onboardings de entities ni el manager de webhook endpoints.

## ¿Qué hay de nuevo?

Alineo el repo con el release que ya existe:

- [x] `version.rb` a 1.3.0
- [x] Entrada de 1.3.0 en el CHANGELOG con todo lo que entró desde 1.2.0: onboardings de entities (con upload de documentos de shareholders y representantes legales), `entities.create`, manager de webhook endpoints y soporte multipart en el cliente
- [x] `Gemfile.lock` actualizado

## Tests

No hay cambios de código, solo versión y changelog. La suite corre igual en CI.

## Safety Checks

- [x] Versión y CHANGELOG actualizados (si corresponde)

## Consideraciones

Ojo: el tag v1.3.0 actual apunta a un commit donde `version.rb` todavía dice 1.2.0, así que si alguien buildea la gema desde el tag le sale una `fintoc-1.2.0.gem`. Después de mergear esto hay que mover el tag (o recrear el release) al commit del merge, y recién ahí publicar a RubyGems con la cuenta `fintoc` (pide MFA).