### PR TITLE
[TRNF-8322] Feat(v2): Support the onboarding type and data create shape

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,47 +411,51 @@ onboardings = entity.onboardings.list
 # shareholders and documents)
 onboarding = entity.onboardings.get('onboarding_id')
 puts onboarding                     # 📋 Onboarding onbprc_0ujs... (in_progress)
+onboarding.type                     # => 'account_holder'
 onboarding.legal_representatives    # => array of legal representative hashes
 onboarding.shareholders             # => array of shareholder hashes
 onboarding.documents                # => array of document hashes
 
-# Create an onboarding. The nested structures are passed through as-is and
-# validated by the API.
+# Create an onboarding. `type` selects the onboarding to run (`account_holder` or
+# `settlement_recipient`) and `data` holds the nested structures, which are passed
+# through as-is and validated by the API.
 onboarding = entity.onboardings.create(
-  company_information: {
-    incorporation_date: '2020-01-01',
-    business_activity: 'Software',
-    legal_name: 'ACME Inc.',
-    fiscal_address: 'Av. Siempre Viva 123',
-    business_address: 'Av. Siempre Viva 123',
-    settlement_account: '1234567890',
-    phone: '+56912345678'
-  },
-  legal_representatives: [
-    {
-      first_name: 'Jane',
-      last_name: 'Doe',
-      email: 'jane@acme.com',
-      nationality: 'CL',
-      identification_number: '12345678-9',
-      position: 'CEO'
-    }
-  ],
-  transactional_profile: {
-    resource_origins: ['sales'],
-    monthly_amount_range: '0-1000000',
-    monthly_operations_range: '0-100'
-  },
-  shareholders: [
-    {
-      type: 'natural_person',
-      name: 'Jane',
-      last_name: 'Doe',
-      holder_id: '12345678-9',
-      nationality: 'CL',
-      percentage: 100
-    }
-  ]
+  type: 'account_holder',
+  data: {
+    company_information: {
+      incorporation_date: '2020-01-15',
+      business_activity: 'Servicios financieros',
+      fiscal_address: 'Av. Reforma 123, CDMX',
+      business_address: 'Av. Insurgentes 456, CDMX',
+      settlement_account: '646180357600000013',
+      phone: '+521111111111'
+    },
+    legal_representatives: [
+      {
+        first_name: 'Jane',
+        last_name: 'Doe',
+        email: 'jane@acme.com',
+        nationality: 'mx',
+        identification_number: 'AAAA010101HDFAAA01',
+        position: 'Director General'
+      }
+    ],
+    transactional_profile: {
+      resource_origins: %w[trusts investments],
+      monthly_amount_range: '1_500000',
+      monthly_operations_range: '1_15000'
+    },
+    shareholders: [
+      {
+        type: 'natural_person',
+        name: 'Jane',
+        last_name: 'Doe',
+        holder_id: 'AAAA010101AAA',
+        nationality: 'mx',
+        percentage: 100
+      }
+    ]
+  }
 )
 
 # Upload a document for a given slot (multipart). `file:` accepts a path or an IO.

--- a/lib/fintoc/v2/resources/onboarding.rb
+++ b/lib/fintoc/v2/resources/onboarding.rb
@@ -1,13 +1,15 @@
 module Fintoc
   module V2
     class Onboarding
-      attr_reader :object, :id, :entity_id, :status, :source, :submitted_at, :reviewed_at,
-                  :submittable, :data, :legal_representatives, :shareholders, :documents
+      attr_reader :object, :id, :entity_id, :type, :status, :source, :submitted_at,
+                  :reviewed_at, :submittable, :data, :legal_representatives, :shareholders,
+                  :documents
 
       def initialize(
         object:,
         id:,
         entity_id: nil,
+        type: nil,
         status: nil,
         source: nil,
         submitted_at: nil,
@@ -23,6 +25,7 @@ module Fintoc
         @object = object
         @id = id
         @entity_id = entity_id
+        @type = type
         @status = status
         @source = source
         @submitted_at = submitted_at

--- a/spec/lib/fintoc/v2/managers/onboardings_manager_spec.rb
+++ b/spec/lib/fintoc/v2/managers/onboardings_manager_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Fintoc::V2::Managers::OnboardingsManager do
       id: onboarding_id,
       object: 'onboarding',
       entity_id: entity_id,
+      type: 'account_holder',
       status: 'in_progress',
       source: 'api',
       submitted_at: nil,
@@ -29,6 +30,7 @@ RSpec.describe Fintoc::V2::Managers::OnboardingsManager do
       id: 'onbprc_other',
       object: 'onboarding',
       entity_id: entity_id,
+      type: 'settlement_recipient',
       status: 'submitted',
       source: 'dashboard',
       submitted_at: '2026-06-22T00:00:00Z',
@@ -48,10 +50,13 @@ RSpec.describe Fintoc::V2::Managers::OnboardingsManager do
 
   let(:create_params) do
     {
-      company_information: { legal_name: 'ACME Inc.' },
-      legal_representatives: [{ first_name: 'Jane', last_name: 'Doe' }],
-      transactional_profile: { monthly_amount_range: '0-1000' },
-      shareholders: [{ type: 'natural_person', name: 'Jane', percentage: 100 }]
+      type: 'account_holder',
+      data: {
+        company_information: { business_activity: 'Servicios financieros' },
+        legal_representatives: [{ first_name: 'Jane', last_name: 'Doe' }],
+        transactional_profile: { monthly_amount_range: '1_500000' },
+        shareholders: [{ type: 'natural_person', name: 'Jane', percentage: 100 }]
+      }
     }
   end
 

--- a/spec/lib/fintoc/v2/onboarding_spec.rb
+++ b/spec/lib/fintoc/v2/onboarding_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe Fintoc::V2::Onboarding do
       id: 'onbprc_0ujs',
       object: 'onboarding',
       entity_id: 'ent_12345',
+      type: 'account_holder',
       status: 'in_progress',
       source: 'api',
       submitted_at: nil,
@@ -79,6 +80,7 @@ RSpec.describe Fintoc::V2::Onboarding do
         id: 'onbprc_0ujs',
         object: 'onboarding',
         entity_id: 'ent_12345',
+        type: 'account_holder',
         status: 'in_progress',
         source: 'api',
         submitted_at: nil,
@@ -110,6 +112,7 @@ RSpec.describe Fintoc::V2::Onboarding do
         id: 'onbprc_0ujs',
         object: 'onboarding',
         entity_id: 'ent_12345',
+        type: 'account_holder',
         status: 'pending',
         source: 'dashboard',
         submitted_at: nil,
@@ -119,9 +122,10 @@ RSpec.describe Fintoc::V2::Onboarding do
 
     let(:light_onboarding) { described_class.new(**light_data) }
 
-    it 'builds without full attributes' do
+    it 'builds without full attributes' do # rubocop:disable RSpec/ExampleLength
       expect(light_onboarding).to have_attributes(
         id: 'onbprc_0ujs',
+        type: 'account_holder',
         status: 'pending',
         source: 'dashboard',
         submittable: nil,


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Contexto

El API público v2 cambió el contrato de creación de onboardings de entities: ahora
exige un `type` (`account_holder` o `settlement_recipient`) y recibe el payload
anidado bajo `data`, en vez de las estructuras al nivel superior. El SDK quedó
documentando y testeando la forma antigua, que hoy responde 422.

## ¿Qué hay de nuevo?

- [x] `Fintoc::V2::Onboarding` expone `type` (el API ya lo devuelve en show e index)
- [x] README: `create` usa `type:` + `data:`, con valores MX reales y los enums vigentes
- [x] README: se documenta el accessor `onboarding.type`

## Tests

- [x] Specs de `Onboarding` cubren `type` en la forma completa y en la liviana
- [x] Spec de `OnboardingsManager` arma el body de `create` con `type` + `data`

## Safety Checks

- [ ] Versión y CHANGELOG actualizados (si corresponde)

## Consideraciones

- El manager pasa los parámetros tal cual al API, así que `create` ya soportaba la
  nueva forma sin cambios: lo que estaba desactualizado eran las specs y el README.
- El upload de documentos de representante legal ya venía de #27; acá solo se
  completa lo que faltaba del schema (`type` y `data`).

## Rollback

Seguro. Es un cambio aditivo (un `attr_reader` nuevo) más documentación y specs;
revertir el commit deja el SDK como estaba.
