### PR TITLE
Add release GitHub Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Tipo de bump'
+        type: choice
+        required: true
+        default: minor
+        options: [patch, minor, major]
+      release-notes:
+        description: 'Release notes (markdown, opcional)'
+        type: string
+        required: false
+
+jobs:
+  release:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2.2'
+          bundler-cache: true
+
+      - run: bundle exec rspec
+
+      - uses: fintoc-com/release-action/prepare@main
+        id: prep
+        with:
+          bump: ${{ inputs.bump }}
+          version-format: ruby
+          tag-prefix: v
+          app-id: ${{ vars.FIN_RELEASES_APP_ID }}
+          app-private-key: ${{ secrets.FIN_RELEASES_PRIVATE_KEY }}
+
+      - uses: rubygems/release-gem@v1
+
+      - uses: fintoc-com/release-action/finalize@main
+        with:
+          tag: ${{ steps.prep.outputs.tag }}
+          release-notes: ${{ inputs.release-notes }}
+          app-id: ${{ vars.FIN_RELEASES_APP_ID }}
+          app-private-key: ${{ secrets.FIN_RELEASES_PRIVATE_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.3.0 - 2026-08-25
+
+### 🚀 New Features
+
+- **Entity Onboardings**: Added `entities` resource with `create`, and `onboardings` under entities, including legal representative document upload
+- **Webhook Endpoints**: Added `webhook_endpoints` manager
+- **Multipart Uploads**: HTTP client now supports `multipart/form-data` requests
+
+### 🐛 Bug Fixes
+
+- **HTTP 6 Compatibility**: Request options are passed as keyword arguments
+
 ## 1.2.0 - 2026-04-08
 
 ### 🚀 New Features

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    fintoc (1.2.0)
+    fintoc (1.3.0)
       http
       money-rails
       tabulate

--- a/lib/fintoc/version.rb
+++ b/lib/fintoc/version.rb
@@ -1,3 +1,3 @@
 module Fintoc
-  VERSION = '1.2.0'
+  VERSION = '1.3.0'
 end


### PR DESCRIPTION
## Contexto

fintoc-node y fintoc-python publican con `fintoc-com/release-action`; este repo aún se releaseaba a mano.

## ¿Qué hay de nuevo?

- [x] Workflow `release.yml`: bump → rspec → publish a RubyGems → tag + GitHub Release
- [x] Publish vía Trusted Publishing (`rubygems/release-gem`), sin API key
- [x] Versión pre-seteada a `1.3.0` para saltar el tag `v1.3.0` ya existente
- [x] Entrada `1.3.0` en el CHANGELOG

## Tests

- [x] Tests unitarios (sin cambios, siguen verdes)

## Safety Checks

- [x] Versión y CHANGELOG actualizados

## Consideraciones

- Antes del primer run hay que registrar el trusted publisher en rubygems.org (`fintoc-com/fintoc-ruby`, `release.yml`)
- El primer `minor` produce `v1.4.0`; `v1.3.0` nunca se publicó a RubyGems

<sup>*Created with Claude Code `/create-pr` command*</sup>

🤖 Generated with [Claude Code](https://claude.com/claude-code)