### PR TITLE
Correr el job de release en Ruby 3.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2.2'
+          ruby-version: '3.4'
           bundler-cache: true
 
       - run: bundle exec rspec


### PR DESCRIPTION
## Contexto

El workflow de release falla al publicar la gem: `bundle exec rake release` explota con un conflicto de activación de `securerandom`.

## ¿Qué hay de nuevo?

- [x] `ruby-version` pasa de `3.2.2` a `3.4` en `release.yml`

## Tests

- [x] Se valida corriendo el workflow de release

## Consideraciones

- `rubygems/release-gem` precarga un patch vía `RUBYOPT` que activa el `securerandom` default de Ruby antes de `Bundler.setup`. Ruby 3.2 trae 0.2.2 y 3.3 trae 0.3.1; el lockfile pide 0.4.1, que es el que trae 3.4.
- El job solo buildea y publica la gem, así que no necesita correr en la Ruby mínima soportada. `ci.yml` sigue cubriendo 3.2, 3.3 y 3.4.

<sup>*Created with Claude Code `/fast-track` command*</sup>